### PR TITLE
Make fewer assumptions in .vimrc In addition to bootstrapping pathogen the .vimrc generated by this module sets the color scheme, background color, enables syntax highlighting, and turns on the indent plugin.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,7 @@ class vim($user, $home_dir) {
 
   file { "${home_dir}/.vimrc": 
     owner   => $user,
-    content => "execute pathogen#infect()\nsyntax on\ncall pathogen#helptags()\nfiletype plugin indent on\nhighlight comment ctermfg=darkgray\n:set bg=dark"
+    content => "execute pathogen#infect()\ncall pathogen#helptags()"
   }
 
   Package['vim'] 


### PR DESCRIPTION
The issue I had was with the color settings but given how easy it is to move other settings into a plugin like [vim-sensible](https:://github.com/tpope/vim-sensible), I think it makes the most sense to make no assumptions and allow others to add vim extensions. It is possible to add but not possible to easily reset to defaults.
